### PR TITLE
ci(travis): update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
-sudo: false
+os: linux
+dist: xenial
 
 git:
   depth: 1
@@ -14,13 +15,13 @@ php:
   - '7.4'
   - master
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - php: master
 
 env:
-  matrix:
+  jobs:
     - DEPENDENCIES="lowest"   LARAVEL="5.6.*"
     - DEPENDENCIES="lowest"   LARAVEL="5.7.*"
     - DEPENDENCIES="lowest"   LARAVEL="5.8.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
     - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest --no-scripts --optimize-autoloader --classmap-authoritative"
 
 install:
-  - composer global require "hirak/prestissimo:^0.3" --prefer-dist --no-progress --no-suggest --classmap-authoritative --ansi
   - if [[ "$DEPENDENCIES" = 'lowest' ]]; then export DEFAULT_COMPOSER_FLAGS="$DEFAULT_COMPOSER_FLAGS --prefer-lowest"; fi
   - composer require illuminate/contracts:${LARAVEL} illuminate/database:${LARAVEL} illuminate/log:${LARAVEL} illuminate/routing:${LARAVEL} illuminate/support:${LARAVEL} $DEFAULT_COMPOSER_FLAGS
 


### PR DESCRIPTION
Update Travis configuration according to warnings.

```
Build config validation
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing dist, using the default xenial
root: missing os, using the default linux
env: key matrix is an alias for jobs, using jobs
root: key matrix is an alias for jobs, using jobs
```