### PR TITLE
fix(RequestResponseCollector): use proper route action name resolver

### DIFF
--- a/src/Collectors/RequestResponseCollector.php
+++ b/src/Collectors/RequestResponseCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Miquido\RequestDataCollector\Collectors;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use Miquido\RequestDataCollector\Collectors\Contracts\ConfigurableInterface;
 use Miquido\RequestDataCollector\Collectors\Contracts\DataCollectorInterface;
 use Miquido\RequestDataCollector\Collectors\Contracts\UsesResponseInterface;
@@ -162,13 +163,13 @@ class RequestResponseCollector implements DataCollectorInterface, ConfigurableIn
 
             $data[self::REQUEST_INFO_ROUTE] = null;
 
-            if (null !== $route) {
+            if ($route instanceof Route) {
                 $data[self::REQUEST_INFO_ROUTE] = [
                     'uri'                => $route->uri,
                     'methods'            => $route->methods,
                     'action'             => $route->action,
                     'isFallback'         => $route->isFallback,
-                    'controller'         => \get_class($route->getController()),
+                    'controller'         => $route->getActionName(),
                     'defaults'           => $route->defaults,
                     'wheres'             => $route->wheres,
                     'parameters'         => $route->parameters,

--- a/tests/Collectors/RequestResponseCollectorTest.php
+++ b/tests/Collectors/RequestResponseCollectorTest.php
@@ -273,7 +273,7 @@ class RequestResponseCollectorTest extends TestCase
         $route->methods = $routeValues['methods'];
         $route->action = $routeValues['action'];
         $route->isFallback = $routeValues['isFallback'];
-        $route->getController()->shouldBeCalled()->willReturn(new self());
+        $route->getActionName()->shouldBeCalled()->willReturn(__CLASS__);
         $route->defaults = $routeValues['defaults'];
         $route->wheres = $routeValues['wheres'];
         $route->parameters = $routeValues['parameters'];


### PR DESCRIPTION
Use `getActionName()` method to resolve controller's action.